### PR TITLE
Add more flexible options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ module.exports = function (package, done) {
 - `concurrency`: (default: 5) Number of concurrent checks to run.
 - `log`: (optional) Log function to use. Expects `console.log` API.
 - `read`: (optional) Options to pass to the `TarBuffer`.
+- `before`: (optional) Stream to pipe to BEFORE piping to the `zlib.Unzip` and `tar.Parse` streams.
+- `cleanup`: (optional) If *explicitly* set to `false` then temporary files will not be cleaned up. Useful for debugging.
 
 #### Events
 - `error`: as with any stream these will be emitted if the readable or writable end of the duplex stream has errored. It will also be emitted if there is an error writing the tarball to the disk cache during the verification process or if the verification fails.

--- a/test/assert.js
+++ b/test/assert.js
@@ -45,6 +45,7 @@ assert.wasVerified = function wasVerified(input, output, done) {
       assert(typeof stats.input, 'object');
       assert(typeof stats.output, 'object');
       assert.equal(stats.input.size, stats.output.size);
+
       done();
     });
   };

--- a/verify-stream.js
+++ b/verify-stream.js
@@ -62,7 +62,8 @@ var VerifyStream = module.exports = function VerifyStream(opts) {
   if (this.before) {
     this.gunzip.pipe(this.parser);
     this.before.pipe(this.gunzip);
-  } else {
+  }
+  else {
     this.writable.pipe(this.parser);
   }
 

--- a/verify-stream.js
+++ b/verify-stream.js
@@ -24,6 +24,7 @@ var VerifyStream = module.exports = function VerifyStream(opts) {
   this.concurrency = opts.concurrency || 5;
   this.before = opts.before;
   this.checks = opts.checks;
+  this.cleanup = opts.cleanup;
 
   this.stream = duplexify();
   this.stream.__verifier = this;

--- a/verify-stream.js
+++ b/verify-stream.js
@@ -23,6 +23,7 @@ var VerifyStream = module.exports = function VerifyStream(opts) {
   this.read = opts.read || {};
   this.read.log = this.read.log || (this.read.log !== false && this.log);
   this.concurrency = opts.concurrency || 5;
+  this.before = opts.before;
   this.checks = opts.checks;
 
   this.stream = duplexify();
@@ -44,8 +45,13 @@ var VerifyStream = module.exports = function VerifyStream(opts) {
   // tarball data as it is written to us.
   //
   this._building = true;
-  this.writable = zlib.Unzip()
+  this.gunzip = zlib.Unzip()
     .on('error', this._cleanup.bind(this));
+
+  this.writable = this.before || this.gunzip;
+  if (this.before) {
+    this.before.pipe(this.gunzip);
+  }
 
   //
   // Do not listen for errors on our tar parser because


### PR DESCRIPTION
1. Add `before` option for adding to the pipe chain
2. Add `cleanup` option which prevents cleanup of files. Useful for debugging.
