### PR TITLE
Use `npm-package-buffer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,31 @@ fs.createReadStream('npm-verify-stream-0.0.0.tgz')
 ```
 
 ## Checks
-A "check" is a function that accepts a fully-read npm package and responds with either no error or an error indicating how the package violated the check.
+A "check" is a function that accepts an [npm-package-buffer][npm-package-buffer] and responds with either no error or an error indicating how the package violated the check.
 
 **example-check.js**
 ``` js
-module.exports = function (package, done) {
+module.exports = function (version, done) {
   //
-  // Really complicated static analysis stuff and whatnot goes here.
+  // `version.package` is a fully JSON parsed the package.json.
   //
+  console.dir(version.package);
+
+  //
+  // `version.files` is all files read into memory
+  //
+  console.dir(version.files);
+
+  //
+  // Respond when done
+  //
+  done();
 };
 ```
 
 ### API
+
+See also: [`npm-package-buffer`][npm-package-buffer], [`tar-buffer`](https://github.com/indexzero/tar-buffer).
 
 #### Options
 
@@ -65,3 +78,5 @@ verifier.on('cleanup', function (file, err) {
 
 ##### Author: [Charlie Robbins](https://github.com/indexzero)
 ##### LICENSE: MIT
+
+[npm-package-buffer]: https://github.com/indexzero/npm-package-buffer

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "concat-stream": "~1.5.0",
     "duplexify": "~3.4.2",
     "fstream": "~1.0.7",
-    "tar": "~2.1.1",
-    "tar-buffer": "^1.0.0"
+    "npm-package-buffer": "^1.0.0",
+    "tar": "~2.1.1"
   },
   "devDependencies": {
     "istanbul": "~0.3.17",

--- a/test/simple.test.js
+++ b/test/simple.test.js
@@ -69,7 +69,15 @@ describe('npm-verify-stream simple', function () {
       var verifier = new VerifyStream({
         log: process.env.DEBUG && console.log,
         cleanup: false,
-        checks: [function noop(pkg, next) {
+        checks: [function noop(ver, next) {
+          assert.ok(!!ver);
+          assert.ok(!!ver.package);
+          assert.ok(!!ver.files);
+
+          assert.equal(typeof ver, 'object');
+          assert.equal(typeof ver.package, 'object');
+          assert.equal(typeof ver.files, 'object');
+
           wasChecked = true;
           next();
         }]

--- a/verify-stream.js
+++ b/verify-stream.js
@@ -9,7 +9,7 @@ var fs = require('fs'),
     duplexify = require('duplexify'),
     fstream = require('fstream'),
     tar = require('tar'),
-    TarBuffer = require('tar-buffer');
+    PackageBuffer = require('npm-package-buffer');
 
 var VerifyStream = module.exports = function VerifyStream(opts) {
   if (!(this instanceof VerifyStream)) { return new VerifyStream(opts); }
@@ -52,10 +52,10 @@ var VerifyStream = module.exports = function VerifyStream(opts) {
 
   //
   // Do not listen for errors on our tar parser because
-  // those errors will be emitted by our TarBuffer.
+  // those errors will be emitted by our PackageBuffer.
   //
   this.parser = tar.Parse();
-  this.buffer = new TarBuffer(this.parser, this.read)
+  this.buffer = new PackageBuffer(this.parser, this.read)
     .on('error', this._cleanup.bind(this))
     .on('end', this.verify.bind(this));
 

--- a/verify-stream.js
+++ b/verify-stream.js
@@ -82,7 +82,7 @@ VerifyStream.prototype.verify = function (files) {
   async.mapLimit(
     this.checks, this.concurrency,
     function runCheck(check, next) {
-      check(files, next);
+      check(self.buffer, next);
     },
     function verifyChecks(err) {
       if (err) { return self._cleanup(err); }


### PR DESCRIPTION
Replaces our usage of `tar-buffer`. 
